### PR TITLE
📝 added contribution guidelines, linked from README.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+Thanks for choosing to contribute!
+
+The following are a set of guidelines to follow when contributing to this project.
+
+## Code Of Conduct
+
+This project adheres to the Adobe [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [Grp-opensourceoffice@adobe.com](mailto:Grp-opensourceoffice@adobe.com).
+
+## Contributor License Agreement
+
+All third-party contributions to this project must be accompanied by a signed contributor license agreement. This gives Adobe permission to redistribute your contributions as part of the project. [Sign our CLA](http://opensource.adobe.com/cla.html). You only need to submit an Adobe CLA one time, so if you have submitted one previously, you are good to go!
+
+## Code Reviews
+
+All submissions should come in the form of pull requests and need to be reviewed by project committers. Read [GitHub's pull request documentation](https://help.github.com/articles/about-pull-requests/) for more information on sending pull requests.

--- a/README.md
+++ b/README.md
@@ -105,3 +105,7 @@ object FeaturePipeline {
 #### References:
 * [An Empirical Analysis of Feature Engineering for
  Predictive Modeling](https://arxiv.org/pdf/1701.07852.pdf)      
+
+### Contributing
+
+If you're interested in contributing to this project, check out our [contribution guidelines](CONTRIBUTING.md)!


### PR DESCRIPTION
Adobe Legal requires that external contributors sign Adobe's CLA. So, added that to the contribution guidelines.