### PR TITLE
Fix issues in some featurizers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>javax.servlet</groupId>
@@ -57,24 +58,28 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
+      <scope>provided</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.databricks/spark-csv_2.11 -->
     <dependency>
       <groupId>com.databricks</groupId>
       <artifactId>spark-csv_${scala.binary.version}</artifactId>
       <version>${spark.csv.version}</version>
+      <scope>provided</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.databricks/spark-avro_2.11 -->
     <dependency>
       <groupId>com.databricks</groupId>
       <artifactId>spark-avro_${scala.binary.version}</artifactId>
       <version>${spark.avro.version}</version>
+      <scope>provided</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-mllib -->
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-mllib_2.11</artifactId>
       <version>${spark.mllib.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -87,6 +92,7 @@
       <groupId>org.json4s</groupId>
       <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
       <version>${json.jackson.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/scala/com/adobe/platform/ml/examples/ConcatenateFeaturizerExample.scala
+++ b/src/main/scala/com/adobe/platform/ml/examples/ConcatenateFeaturizerExample.scala
@@ -1,0 +1,41 @@
+/** ***********************************************************************
+  * ADOBE CONFIDENTIAL
+  * ___________________
+  * <p>
+  * Copyright 2018 Adobe
+  * All Rights Reserved.
+  * <p>
+  * NOTICE: All information contained herein is, and remains
+  * the property of Adobe and its suppliers, if any. The intellectual
+  * and technical concepts contained herein are proprietary to Adobe
+  * and its suppliers and are protected by all applicable intellectual
+  * property laws, including trade secret and copyright laws.
+  * Dissemination of this information or reproduction of this material
+  * is strictly forbidden unless prior written permission is obtained
+  * from Adobe.
+  * *************************************************************************/
+package com.adobe.platform.ml.examples
+
+import com.adobe.platform.ml.feature.binary.string.ConcateColumnsFeaturizer
+import org.apache.spark.sql.SparkSession
+
+object ConcatenateFeaturizerExample {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder().appName("ConcatenateFeaturizer").master("local").getOrCreate()
+    spark.sparkContext.setLogLevel("ERROR")
+
+    val data = Array((0, "2018-01-02","F","high","red"),
+      (1, "2018-02-02","M","high","yellow"),
+      (2, "2018-03-02","F","high","red"),
+      (3, "2018-04-05","M","low","black"),
+      (3, "2018-05-05","F","medium","red"))
+    val dataFrame = spark.createDataFrame(data).toDF("id", "date","gender","level","color")
+
+    val featurizer = new ConcateColumnsFeaturizer()
+      .setInputCols(Array("gender","level","color"))
+      .setOutputCol("g_l_g")
+
+    val featurizedDataFrame = featurizer.transform(dataFrame)
+    featurizedDataFrame.show()
+  }
+}

--- a/src/main/scala/com/adobe/platform/ml/feature/unary/numeric/LogTransformFeaturizer.scala
+++ b/src/main/scala/com/adobe/platform/ml/feature/unary/numeric/LogTransformFeaturizer.scala
@@ -20,7 +20,7 @@ import com.adobe.platform.ml.feature.util.{HasInputCol, HasOutputCol}
 import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.param.{Param, ParamMap, Params}
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Dataset, functions}
 
@@ -58,15 +58,18 @@ class LogTransformFeaturizer(override val uid: String)
     val schema = dataset.schema
     val inputType = schema($(inputCol)).dataType
     val metadata = outputSchema($(outputCol)).metadata
+
+    val addOneIfZero = udf { in: Double => if (in == 0) 1.0 else in }
+
     getLogType match {
       case "natural" => {
-        dataset.select(col("*"), (functions.log($(inputCol)).as($(outputCol), metadata)))
+        dataset.select(col("*"), functions.log(addOneIfZero(col($(inputCol)))).as($(outputCol), metadata))
       }
       case "log10" => {
-        dataset.select(col("*"), (functions.log10($(inputCol)).as($(outputCol), metadata)))
+        dataset.select(col("*"), functions.log10(addOneIfZero(col($(inputCol)))).as($(outputCol), metadata))
       }
       case "log2" => {
-        dataset.select(col("*"), (functions.log2($(inputCol)).as($(outputCol), metadata)))
+        dataset.select(col("*"), functions.log2(addOneIfZero(col($(inputCol)))).as($(outputCol), metadata))
       }
     }
   }

--- a/src/main/scala/com/adobe/platform/ml/feature/unary/numeric/MathFeaturizer.scala
+++ b/src/main/scala/com/adobe/platform/ml/feature/unary/numeric/MathFeaturizer.scala
@@ -74,6 +74,12 @@ class MathFeaturizer(override val uid: String)
       case "log2" => {
         dataset.select(col("*"), (functions.log2($(inputCol)).as($(outputCol), metadata)))
       }
+      case "square" => {
+        dataset.select(col("*"), (functions.pow($(inputCol),2).as($(outputCol), metadata)))
+      }
+      case "exp" => {
+        dataset.select(col("*"), (functions.exp($(inputCol)).as($(outputCol), metadata)))
+      }
     }
   }
 

--- a/src/main/scala/com/adobe/platform/ml/feature/unary/numeric/PowerTransformFeaturizer.scala
+++ b/src/main/scala/com/adobe/platform/ml/feature/unary/numeric/PowerTransformFeaturizer.scala
@@ -25,10 +25,9 @@ import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Dataset, functions}
 
 private[feature] trait PowerTransformFeaturizerParams extends Params with HasInputCol with HasOutputCol {
+  final val powerType: Param[String] = new Param(this, "powerType", s"Power function type.")
 
-  final val powerType: Param[Int] = new Param(this, "powerType", s"Power function type.")
-
-  def getPowerType: Int = $(powerType)
+  def getPowerType: String = $(powerType)
 
   /** Validates and transforms the input schema. */
   protected def validateAndTransformSchema(schema: StructType): StructType = {
@@ -48,9 +47,9 @@ class PowerTransformFeaturizer(override val uid: String)
 
   def setOutputCol(value: String): this.type = set(outputCol, value)
 
-  def setPowerType(value: Int): this.type = set(powerType, value)
+  def setPowerType(value: String): this.type = set(powerType, value)
 
-  setDefault(powerType -> 2)
+  setDefault(powerType -> "2")
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
@@ -58,7 +57,7 @@ class PowerTransformFeaturizer(override val uid: String)
     val schema = dataset.schema
     val inputType = schema($(inputCol)).dataType
     val metadata = outputSchema($(outputCol)).metadata
-    dataset.select(col("*"), (functions.pow($(inputCol), getPowerType).as($(outputCol), metadata)))
+    dataset.select(col("*"), (functions.pow($(inputCol), getPowerType.toInt).as($(outputCol), metadata)))
   }
 
   override def transformSchema(schema: StructType): StructType = {


### PR DESCRIPTION
Changes:
pom.xml: Add provided scope to Spark dependencies.
ConcatenateFeaturizerExample.scala: Example of using ConcateFeaturizer
ConcateColumnsFeaturizer.scala: Add capability to add more than 2 columns as inputs
LogTransformFeaturizer.scala: Handle zeros 
MathFeaturizer.scala: Add more default math options, square and exponential
PowerTransformFeaturizer.scala: Use String for powerType param