### PR TITLE
Add unit tests for binary numeric featurizers

### DIFF
--- a/src/test/scala/com/adobe/platform/ml/feature/binary/numeric/AdditionFeaturizerSuite.scala
+++ b/src/test/scala/com/adobe/platform/ml/feature/binary/numeric/AdditionFeaturizerSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.platform.ml.feature.binary.numeric
+
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
+
+class AdditionFeaturizerSuite extends MLTest with DefaultReadWriteTest {
+  import testImplicits._
+
+  test("AdditionFeaturizer params") {
+    ParamsSuite.checkParams(new AdditionFeaturizer())
+  }
+
+  test("Addition of two columns") {
+    val original = Seq((0, 1.0, 3.0), (2, 2.0, 5.0),(3, -1.0, 2.0), (5, -5.0, -8.0),
+      (8, 100.0, 200.0)).toDF("id", "v1", "v2")
+    val featurizer = new AdditionFeaturizer().setInputCols("v1", "v2").setOutputCol("v3")
+    val expected = Seq((0, 1.0, 3.0, 4.0), (2, 2.0, 5.0, 7.0), (3, -1.0, 2.0, 1.0),
+      (5, -5.0, -8.0, -13.0), (8, 100.0, 200.0, 300.0)).toDF("id", "v1", "v2", "v3")
+    val resultSchema = featurizer.transformSchema(original.schema)
+    testTransformerByGlobalCheckFunc[(Int, Double, Double)](
+      original,
+      featurizer,
+      "id",
+      "v1",
+      "v2",
+      "v3") { rows =>
+      assert(rows.head.schema.toString == resultSchema.toString)
+      assert(resultSchema == expected.schema)
+      assert(rows == expected.collect().toSeq)
+    }
+  }
+
+  test("AdditionFeaturizer read/write") {
+    val t = new AdditionFeaturizer()
+      .setInputCols("myInputCol1","myInputCol2")
+      .setOutputCol("myOutputCol")
+    testDefaultReadWrite(t)
+  }
+}

--- a/src/test/scala/com/adobe/platform/ml/feature/binary/numeric/DivisionFeaturizerSuite.scala
+++ b/src/test/scala/com/adobe/platform/ml/feature/binary/numeric/DivisionFeaturizerSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.platform.ml.feature.binary.numeric
+
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.sql.Row
+import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
+
+
+class DivisionFeaturizerSuite extends MLTest with DefaultReadWriteTest {
+  import testImplicits._
+
+  def assertResult: Row => Unit = {
+    case Row(transformedValue:Double, expectedValue:Double) =>
+      assert(transformedValue ~== expectedValue absTol 1E-5,
+        "The transformed value is not correct after division.")
+  }
+
+  test("DivisonFeaturizer params") {
+    ParamsSuite.checkParams(new DivisionFeaturizer())
+  }
+
+  test("Division of two columns") {
+    val original = Seq((0, 4.0, 2.0, 2.0), (2, 15.0, 5.0, 3.0), (3, -5.0, 1.0, -5.0), (5, -9.0, -3.0, 3.0),
+      (8, 200.0, 100.0, 2.0), (9, 200.0, 8.3, 24.09639), (10, 105.0, 3.9, 26.92308)).toDF("id", "v1", "v2", "expected")
+    val featurizer = new DivisionFeaturizer().setInputCols("v1", "v2").setOutputCol("v3")
+    testTransformerByGlobalCheckFunc[(Int, Double, Double, Double)](
+      original,
+      featurizer,
+      "v3",
+      "expected") {
+      rows => rows.foreach(assertResult)
+    }
+  }
+
+  test("DivisionFeaturizer read/write") {
+    val t = new DivisionFeaturizer()
+      .setInputCols("myInputCol1","myInputCol2")
+      .setOutputCol("myOutputCol")
+    testDefaultReadWrite(t)
+  }
+}

--- a/src/test/scala/com/adobe/platform/ml/feature/binary/numeric/MultiplicationFeaturizerSuite.scala
+++ b/src/test/scala/com/adobe/platform/ml/feature/binary/numeric/MultiplicationFeaturizerSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.platform.ml.feature.binary.numeric
+
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
+
+class MultiplicationFeaturizerSuite extends MLTest with DefaultReadWriteTest {
+  import testImplicits._
+
+  test("MultiplicationFeaturizer params") {
+    ParamsSuite.checkParams(new MultiplicationFeaturizer())
+  }
+
+  test("Multiplication of two columns") {
+    val original = Seq((0, 1.0, 3.0), (2, 2.0, 5.0),(3, -1.0, 2.0), (5, -5.0, -8.0),
+      (8, 100.0, 200.0)).toDF("id", "v1", "v2")
+    val featurizer = new MultiplicationFeaturizer().setInputCols("v1", "v2").setOutputCol("v3")
+    val expected = Seq((0, 1.0, 3.0, 3.0), (2, 2.0, 5.0, 10.0), (3, -1.0, 2.0, -2.0),
+      (5, -5.0, -8.0, 40.0), (8, 100.0, 200.0, 20000.0)).toDF("id", "v1", "v2", "v3")
+    val resultSchema = featurizer.transformSchema(original.schema)
+    testTransformerByGlobalCheckFunc[(Int, Double, Double)](
+      original,
+      featurizer,
+      "id",
+      "v1",
+      "v2",
+      "v3") { rows =>
+      assert(rows.head.schema.toString == resultSchema.toString)
+      assert(resultSchema == expected.schema)
+      assert(rows == expected.collect().toSeq)
+    }
+  }
+
+  test("MultiplicationFeaturizer read/write") {
+    val t = new MultiplicationFeaturizer()
+      .setInputCols("myInputCol1","myInputCol2")
+      .setOutputCol("myOutputCol")
+    testDefaultReadWrite(t)
+  }
+}

--- a/src/test/scala/com/adobe/platform/ml/feature/binary/numeric/SubtractionFeaturizerSuite.scala
+++ b/src/test/scala/com/adobe/platform/ml/feature/binary/numeric/SubtractionFeaturizerSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.platform.ml.feature.binary.numeric
+
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
+
+class SubtractionFeaturizerSuite extends MLTest with DefaultReadWriteTest {
+  import testImplicits._
+
+  test("SubtractionFeaturizer params") {
+    ParamsSuite.checkParams(new SubtractionFeaturizer())
+  }
+
+  test("Subtraction of two columns") {
+    val original = Seq((0, 1.0, 3.0), (2, 2.0, 5.0),(3, -1.0, 2.0), (5, -5.0, -8.0),
+      (8, 200.0, 100.0)).toDF("id", "v1", "v2")
+    val featurizer = new SubtractionFeaturizer().setInputCols("v1", "v2").setOutputCol("v3")
+    val expected = Seq((0, 1.0, 3.0, -2.0), (2, 2.0, 5.0, -3.0), (3, -1.0, 2.0, -3.0),
+      (5, -5.0, -8.0, 3.0), (8, 200.0, 100.0, 100.0)).toDF("id", "v1", "v2", "v3")
+    val resultSchema = featurizer.transformSchema(original.schema)
+    testTransformerByGlobalCheckFunc[(Int, Double, Double)](
+      original,
+      featurizer,
+      "id",
+      "v1",
+      "v2",
+      "v3") { rows =>
+      assert(rows.head.schema.toString == resultSchema.toString)
+      assert(resultSchema == expected.schema)
+      assert(rows == expected.collect().toSeq)
+    }
+  }
+
+  test("SubtractionFeaturizer read/write") {
+    val t = new SubtractionFeaturizer()
+      .setInputCols("myInputCol1","myInputCol2")
+      .setOutputCol("myOutputCol")
+    testDefaultReadWrite(t)
+  }
+}

--- a/src/test/scala/com/adobe/platform/ml/feature/unary/numeric/LogTransformFeaturizerSuite.scala
+++ b/src/test/scala/com/adobe/platform/ml/feature/unary/numeric/LogTransformFeaturizerSuite.scala
@@ -27,8 +27,8 @@ class LogTransformFeaturizerSuite extends MLTest with DefaultReadWriteTest {
   import testImplicits._
 
   def assertResult: Row => Unit = {
-    case Row(originalValue:Double, transformedValue:Double) =>
-      assert(originalValue ~== transformedValue absTol 1E-5,
+    case Row(transformedValue:Double, expectedValue:Double) =>
+      assert(transformedValue ~== expectedValue absTol 1E-5,
         "The transformed value is not correct after log transform.")
   }
 

--- a/src/test/scala/com/adobe/platform/ml/feature/unary/numeric/PowerTransformFeaturizerSuite.scala
+++ b/src/test/scala/com/adobe/platform/ml/feature/unary/numeric/PowerTransformFeaturizerSuite.scala
@@ -27,8 +27,8 @@ class PowerTransformFeaturizerSuite extends MLTest with DefaultReadWriteTest {
   import testImplicits._
 
   def assertResult: Row => Unit = {
-    case Row(originalValue:Double, transformedValue:Double) =>
-      assert(originalValue ~== transformedValue absTol 1E-5,
+    case Row(transformedValue:Double, expectedValue:Double) =>
+      assert(transformedValue ~== expectedValue absTol 1E-5,
         "The transformed value is not correct after power transform.")
   }
 


### PR DESCRIPTION
Add
src/test/scala/com/adobe/platform/ml/feature/binary/numeric/AdditionFeaturizerSuite.scala
src/test/scala/com/adobe/platform/ml/feature/binary/numeric/DivisionFeaturizerSuite.scala
src/test/scala/com/adobe/platform/ml/feature/binary/numeric/MultiplicationFeaturizerSuite.scala
src/test/scala/com/adobe/platform/ml/feature/binary/numeric/SubtractionFeaturizerSuite.scala