### PR TITLE
Add unit tests for temporal type featurizers

### DIFF
--- a/src/main/scala/com/adobe/platform/ml/examples/DayOfWeekFeaturizerExample.scala
+++ b/src/main/scala/com/adobe/platform/ml/examples/DayOfWeekFeaturizerExample.scala
@@ -16,15 +16,18 @@
  */
 package com.adobe.platform.ml.examples
 
+import java.sql.Timestamp
+
 import com.adobe.platform.ml.feature.unary.temporal.DayOfWeekFeaturizer
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.types.{StructType, StructField, TimestampType, IntegerType}
 
 object DayOfWeekFeaturizerExample {
   def main(args: Array[String]): Unit = {
     val spark = SparkSession.builder().appName("DayOfWeekFeaturizer").master("local").getOrCreate()
     spark.sparkContext.setLogLevel("ERROR")
 
-    //Sunday: 1, Monday:2, Tuesday:3, Wednesday:4, Thursday:5, Friday:6, Saturday:7
+    //Sunday: 7, Monday:1, Tuesday:2, Wednesday:3, Thursday:4, Friday:5, Saturday:6
     val data = Array((0, "2018-01-02"),
       (1, "2018-02-02"),
       (2, "2018-03-02"),
@@ -39,5 +42,48 @@ object DayOfWeekFeaturizerExample {
 
     val featurizedDataFrame = featurizer.transform(dataFrame)
     featurizedDataFrame.show()
+
+    val dataWithTime = Array((0, "2018-01-02 050000"),
+      (1, "2018-02-02 120000"),
+      (2, "2018-03-02 150000"),
+      (3, "2018-04-05 200000"),
+      (3, "2018-05-05 230000"))
+
+    val dataFrameWithTime = spark.createDataFrame(dataWithTime).toDF("id", "date")
+    dataFrameWithTime.printSchema()
+
+    val featurizerHandleTime = new DayOfWeekFeaturizer()
+      .setInputCol("date")
+      .setOutputCol("dayOfWeek")
+      .setFormat("yyyy-MM-dd HHmmss")
+
+    val featurizedDataFrameWithTime = featurizerHandleTime.transform(dataFrameWithTime)
+    featurizedDataFrameWithTime.show()
+
+    val dataWithTimestamp = Array(Row(0, Timestamp.valueOf("2018-01-02 05:00:00")),
+      Row(1, Timestamp.valueOf("2018-02-02 12:00:00")),
+      Row(2, Timestamp.valueOf("2018-03-02 15:00:00")),
+      Row(3, Timestamp.valueOf("2018-04-05 20:00:00")),
+      Row(3, Timestamp.valueOf("2018-05-05 23:00:00")))
+
+    val schema = List(
+      StructField("id", IntegerType, true),
+      StructField("date", TimestampType, true)
+    )
+
+    val dataFrameWithTimestamp = spark.createDataFrame(
+      spark.sparkContext.parallelize(dataWithTimestamp),
+      StructType(schema)
+    )
+
+    dataFrameWithTimestamp.printSchema()
+
+    val featurizerHandleTimestamp = new DayOfWeekFeaturizer()
+      .setInputCol("date")
+      .setOutputCol("dayOfWeek")
+      .setFormat("yyyy-MM-dd HH:mm:ss")
+
+    val featurizedDataFrameWithTimestamp = featurizerHandleTimestamp.transform(dataFrameWithTimestamp)
+    featurizedDataFrameWithTimestamp.show()
   }
 }

--- a/src/main/scala/com/adobe/platform/ml/feature/unary/temporal/DayOfWeekFeaturizer.scala
+++ b/src/main/scala/com/adobe/platform/ml/feature/unary/temporal/DayOfWeekFeaturizer.scala
@@ -17,10 +17,11 @@
 package com.adobe.platform.ml.feature.unary.temporal
 
 import java.sql.Timestamp
-import java.text.SimpleDateFormat
-import java.util.Calendar
+import java.time._
+import java.time.format.{DateTimeFormatterBuilder, DateTimeFormatter}
+import java.time.temporal.ChronoField
 
-import com.adobe.platform.ml.feature.util.{HasInputCol, HasOutputCol}
+import com.adobe.platform.ml.feature.util.{TemporalFeaturizerUtils, HasInputCol, HasOutputCol}
 import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.param.{Param, ParamMap, Params}
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
@@ -34,9 +35,11 @@ import org.apache.spark.sql.{DataFrame, Dataset}
 private[feature] trait DayOfWeekFeaturizerParams extends Params with HasInputCol with HasOutputCol {
 
   final val format: Param[String] = new Param(this, "format", s"Date time format.")
+  final val timezone: Param[String] = new Param(this, "timezone", s"Timezone used.")
 
   /** @group getParam */
   def getFormat: String = $(format)
+  def getTimezone: String = $(timezone)
 
   /** Validates and transforms the input schema. */
   protected def validateAndTransformSchema(schema: StructType): StructType = {
@@ -60,28 +63,36 @@ class DayOfWeekFeaturizer(override val uid: String)
 
   def setFormat(value: String): this.type = set(format, value)
 
-  setDefault(format -> "yyyy-MM-dd")
-  val formatter = new SimpleDateFormat(getFormat)
+  def setTimezone(value: String): this.type = set(timezone, value)
+
+  setDefault(format -> "yyyy-MM-dd", timezone -> ZoneId.systemDefault().getId)
+  val includedFormats = Set("uuuu-MM-dd HH:mm:ss","uuuu-MM-dd")
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     val outputSchema = transformSchema(dataset.schema, logging = true)
     val schema = dataset.schema
     val inputType = schema($(inputCol)).dataType
+    val updatedFormats =  TemporalFeaturizerUtils.updateFormats(includedFormats, getFormat)
+
+    val formatter = new DateTimeFormatterBuilder()
+      .appendPattern(updatedFormats)
+      .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+      .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+      .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+      .toFormatter()
+      .withZone(ZoneId.of(getTimezone))
 
     val toDayOfWeekString = udf {
       in: String => {
-        val date = formatter.parse(in)
-        val calendar = Calendar.getInstance
-        calendar.setTime(date)
-        val dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK)
+        val date = LocalDateTime.parse(in, formatter)
+        val  zonedDateTime = ZonedDateTime.of(date, ZoneId.of(getTimezone))
+        val dayOfWeek = zonedDateTime.getDayOfWeek.getValue
         dayOfWeek
       }
     }
     val toDayOfWeekTimestamp = udf {
       in: Timestamp => {
-        val calendar = Calendar.getInstance
-        calendar.setTime(in)
-        val dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK)
+        val dayOfWeek = in.toLocalDateTime().toLocalDate().getDayOfWeek.getValue
         dayOfWeek
       }
     }

--- a/src/main/scala/com/adobe/platform/ml/feature/unary/temporal/HourOfDayFeaturizer.scala
+++ b/src/main/scala/com/adobe/platform/ml/feature/unary/temporal/HourOfDayFeaturizer.scala
@@ -17,10 +17,11 @@
 package com.adobe.platform.ml.feature.unary.temporal
 
 import java.sql.Timestamp
-import java.text.SimpleDateFormat
-import java.util.Calendar
+import java.time.{ZonedDateTime, LocalDateTime, ZoneId}
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
 
-import com.adobe.platform.ml.feature.util.{HasInputCol, HasOutputCol}
+import com.adobe.platform.ml.feature.util.{TemporalFeaturizerUtils, HasInputCol, HasOutputCol}
 import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.param.{Param, ParamMap, Params}
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
@@ -29,11 +30,12 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Dataset}
 
 private[feature] trait HourOfDayFeaturizerParams extends Params with HasInputCol with HasOutputCol {
-
   final val format: Param[String] = new Param(this, "format", s"Date time format.")
+  final val timezone: Param[String] = new Param(this, "timezone", s"Timezone used.")
 
   /** @group getParam */
   def getFormat: String = $(format)
+  def getTimezone: String = $(timezone)
 
   /** Validates and transforms the input schema. */
   protected def validateAndTransformSchema(schema: StructType): StructType = {
@@ -55,30 +57,39 @@ class HourOfDayFeaturizer(override val uid: String)
 
   def setFormat(value: String): this.type = set(format, value)
 
-  setDefault(format -> "yyyy-MM-dd HH:mm:ss")
-  val formatter = new SimpleDateFormat(getFormat)
+  def setTimezone(value: String): this.type = set(timezone, value)
+
+  setDefault(format -> "yyyy-MM-dd HH:mm:ss", timezone -> ZoneId.systemDefault().getId)
+
+  val includedFormats = Set("uuuu-MM-dd HH:mm:ss","uuuu-MM-dd")
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
     val outputSchema = transformSchema(dataset.schema, logging = true)
     val schema = dataset.schema
     val inputType = schema($(inputCol)).dataType
+    val updatedFormats =  TemporalFeaturizerUtils.updateFormats(includedFormats, getFormat)
+
+    val formatter = new DateTimeFormatterBuilder()
+      .appendPattern(updatedFormats)
+      .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+      .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+      .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+      .toFormatter()
+      .withZone(ZoneId.of(getTimezone))
 
     val toHourOfDayString = udf {
       in: String => {
-        val date = formatter.parse(in)
-        val calendar = Calendar.getInstance
-        calendar.setTime(date)
-        val hour = calendar.get(Calendar.HOUR_OF_DAY)
+        val date = LocalDateTime.parse(in, formatter)
+        val  zonedDateTime = ZonedDateTime.of(date, ZoneId.of(getTimezone))
+        val hour = zonedDateTime.getHour
         hour
       }
     }
 
     val toHourOfDayTimestamp = udf {
       in: Timestamp => {
-        val calendar = Calendar.getInstance
-        calendar.setTime(in)
-        val hour = calendar.get(Calendar.HOUR_OF_DAY)
+        val hour = in.toLocalDateTime().getHour()
         hour
       }
     }

--- a/src/main/scala/com/adobe/platform/ml/feature/util/TemporalFeaturizerUtils.scala
+++ b/src/main/scala/com/adobe/platform/ml/feature/util/TemporalFeaturizerUtils.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.platform.ml.feature.util
+
+object TemporalFeaturizerUtils {
+  def updateFormats(includedFormats:Set[String], format:String):String = {
+    if(includedFormats.contains(format))  {
+      "[uuuu-MM-dd HH:mm:ss][uuuu-MM-dd]"
+    }
+    else {
+      s"[${format}][uuuu-MM-dd HH:mm:ss][uuuu-MM-dd]"
+    }
+  }
+}

--- a/src/test/scala/com/adobe/platform/ml/feature/unary/temporal/DayOfWeekFeaturizerSuite.scala
+++ b/src/test/scala/com/adobe/platform/ml/feature/unary/temporal/DayOfWeekFeaturizerSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.platform.ml.feature.unary.temporal
+
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.sql.Row
+import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
+
+
+class DayOfWeekFeaturizerSuite extends MLTest with DefaultReadWriteTest {
+  import testImplicits._
+
+  def assertResult: Row => Unit = {
+    case Row(transformedValue:Int, expectedValue:Int) =>
+      assert(transformedValue === expectedValue,
+        "The transformed value is not correct after day of week transform.")
+  }
+
+  test("params") {
+    ParamsSuite.checkParams(new DayOfWeekFeaturizer())
+  }
+
+  test("Default Day of Week Transform") {
+    val data = Seq("2018-08-01", "2018-05-25")
+    val expected = Seq(3, 5)
+    val df = data.zip(expected).toSeq.toDF("created", "expectedDayOfWeek")
+
+    val featurizer = new DayOfWeekFeaturizer()
+      .setInputCol("created")
+      .setOutputCol("dayOfWeek")
+      .setFormat("yyyy-MM-dd")
+
+    testTransformer[(String, Int)](df, featurizer, "dayOfWeek", "expectedDayOfWeek")(
+      assertResult)
+  }
+
+  test("Day of Week Transform with format yyyy-MM-dd HH:mm:ss") {
+    val data = Seq("2018-08-01 01:00:00", "2018-05-25 12:00:00", "2019-03-15 00:00:00", "2015-09-03 18:00:00")
+    val expected = Seq(3, 5, 5, 4)
+    val df = data.zip(expected).toSeq.toDF("created", "expectedDayOfWeek")
+
+    val featurizer = new DayOfWeekFeaturizer()
+      .setInputCol("created")
+      .setOutputCol("dayOfWeek")
+      .setFormat("yyyy-MM-dd HH:mm:ss")
+
+    testTransformer[(String, Int)](df, featurizer, "dayOfWeek", "expectedDayOfWeek")(
+      assertResult)
+  }
+
+  test("Day of Week Transform with format yyyyMMddHHmmss") {
+    val data = Seq("20180801010000", "20180525120000", "20190315000000", "20150903180000")
+    val expected = Seq(3, 5, 5, 4)
+    val df = data.zip(expected).toSeq.toDF("created", "expectedDayOfWeek")
+
+    val featurizer = new DayOfWeekFeaturizer()
+      .setInputCol("created")
+      .setOutputCol("dayOfWeek")
+      .setFormat("yyyyMMddHHmmss")
+      .setTimezone("US/Central")
+
+    testTransformer[(String, Int)](df, featurizer, "dayOfWeek", "expectedDayOfWeek")(
+      assertResult)
+  }
+
+
+  test("DayOfWeekFeaturizer read/write") {
+    val t = new DayOfWeekFeaturizer()
+      .setInputCol("myInputCol")
+      .setOutputCol("myOutputCol")
+      .setFormat("yyyyMMddHHmmss")
+      .setTimezone("US/Central")
+    testDefaultReadWrite(t)
+  }
+}

--- a/src/test/scala/com/adobe/platform/ml/feature/unary/temporal/HourOfDayFeaturizerSuite.scala
+++ b/src/test/scala/com/adobe/platform/ml/feature/unary/temporal/HourOfDayFeaturizerSuite.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.platform.ml.feature.unary.temporal
+
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.sql.Row
+import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
+
+
+class HourOfDayFeaturizerSuite extends MLTest with DefaultReadWriteTest {
+  import testImplicits._
+
+  def assertResult: Row => Unit = {
+    case Row(transformedValue:Int, expectedValue:Int) =>
+      assert(transformedValue === expectedValue,
+        "The transformed value is not correct after hour of day transform.")
+  }
+
+  test("params") {
+    ParamsSuite.checkParams(new HourOfDayFeaturizer())
+  }
+
+  test("Default Hour of Day Transform") {
+    val data = Seq("2018-08-01 00:00:00", "2018-05-25 12:00:00")
+    val expected = Seq(0, 12)
+    val df = data.zip(expected).toSeq.toDF("created", "expectedHourOfDay")
+
+    val featurizer = new HourOfDayFeaturizer()
+      .setInputCol("created")
+      .setOutputCol("hourOfDay")
+      .setFormat("yyyy-MM-dd HH:mm:ss")
+
+    testTransformer[(String, Int)](df, featurizer, "hourOfDay", "expectedHourOfDay")(
+      assertResult)
+  }
+
+  test("Hour of Day Transform with format yyyy-MM-dd HH:mm") {
+    val data = Seq("2018-08-01 01:00", "2018-05-25 12:00", "2019-03-15 00:00", "2015-09-03 18:00")
+    val expected = Seq(1, 12, 0, 18)
+    val df = data.zip(expected).toSeq.toDF("created", "expectedHourOfDay")
+
+    val featurizer = new HourOfDayFeaturizer()
+      .setInputCol("created")
+      .setOutputCol("hourOfDay")
+      .setFormat("yyyy-MM-dd HH:mm")
+
+    testTransformer[(String, Int)](df, featurizer, "hourOfDay", "expectedHourOfDay")(
+      assertResult)
+  }
+
+
+  test("Hour of Day Transform with format yyyyMMddHHmmss") {
+    val data = Seq("20180801010000", "20180525120000", "20190315000000", "20150903180000")
+    val expected = Seq(1, 12, 0, 18)
+    val df = data.zip(expected).toSeq.toDF("created", "expectedHourOfDay")
+
+    val featurizer = new HourOfDayFeaturizer()
+      .setInputCol("created")
+      .setOutputCol("hourOfDay")
+      .setFormat("yyyyMMddHHmmss")
+      .setTimezone("US/Central")
+
+    testTransformer[(String, Int)](df, featurizer, "hourOfDay", "expectedHourOfDay")(
+      assertResult)
+  }
+
+
+  test("HourOfDayFeaturizer read/write") {
+    val t = new HourOfDayFeaturizer()
+      .setInputCol("created")
+      .setOutputCol("hourOfDay")
+      .setFormat("yyyy-MM-dd HH:mm:ss")
+      .setTimezone("US/Central")
+    testDefaultReadWrite(t)
+  }
+}

--- a/src/test/scala/com/adobe/platform/ml/feature/unary/temporal/MonthOfYearFeaturizerSuite.scala
+++ b/src/test/scala/com/adobe/platform/ml/feature/unary/temporal/MonthOfYearFeaturizerSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.platform.ml.feature.unary.temporal
+
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest}
+import org.apache.spark.sql.Row
+
+
+class MonthOfYearFeaturizerSuite extends MLTest with DefaultReadWriteTest {
+  import testImplicits._
+
+  def assertResult: Row => Unit = {
+    case Row(transformedValue:Int, expectedValue:Int) =>
+      assert(transformedValue === expectedValue,
+        "The transformed value is not correct after month of year transform.")
+  }
+
+  test("params") {
+    ParamsSuite.checkParams(new MonthOfYearFeaturizer())
+  }
+
+  test("Default Month of Year Transform") {
+    val data = Seq("2018-08-01 00:00:00", "2018-05-25 12:00:00")
+    val expected = Seq(8, 5)
+    val df = data.zip(expected).toSeq.toDF("created", "expectedMonthOfYear")
+
+    val featurizer = new MonthOfYearFeaturizer()
+      .setInputCol("created")
+      .setOutputCol("monthOfYear")
+      .setFormat("yyyy-MM-dd HH:mm:ss")
+
+    testTransformer[(String, Int)](df, featurizer, "monthOfYear", "expectedMonthOfYear")(
+      assertResult)
+  }
+
+  test("Month of Year Transform with format yyyy-MM-dd HH:mm") {
+    val data = Seq("2018-08-01 01:00", "2018-05-25 12:00", "2019-03-15 00:00", "2015-09-03 18:00")
+    val expected = Seq(8, 5, 3, 9)
+    val df = data.zip(expected).toSeq.toDF("created", "expectedMonthOfYear")
+
+    val featurizer = new MonthOfYearFeaturizer()
+      .setInputCol("created")
+      .setOutputCol("monthOfYear")
+      .setFormat("yyyy-MM-dd HH:mm")
+
+    testTransformer[(String, Int)](df, featurizer, "monthOfYear", "expectedMonthOfYear")(
+      assertResult)
+  }
+
+
+  test("Month of Year Transform with format yyyyMMddHHmmss") {
+    val data = Seq("20180801010000", "20180525120000", "20190315000000", "20150903180000")
+    val expected = Seq(8, 5, 3, 9)
+    val df = data.zip(expected).toSeq.toDF("created", "expectedMonthOfYear")
+
+    val featurizer = new MonthOfYearFeaturizer()
+      .setInputCol("created")
+      .setOutputCol("monthOfYear")
+      .setFormat("yyyyMMddHHmmss")
+      .setTimezone("US/Central")
+
+    testTransformer[(String, Int)](df, featurizer, "monthOfYear", "expectedMonthOfYear")(
+      assertResult)
+  }
+
+
+  test("MonthOfYearFeaturizer read/write") {
+    val t = new MonthOfYearFeaturizer()
+      .setInputCol("created")
+      .setOutputCol("monthOfYear")
+      .setFormat("yyyy-MM-dd HH:mm:ss")
+      .setTimezone("US/Central")
+    testDefaultReadWrite(t)
+  }
+}


### PR DESCRIPTION
Add DayOfWeekFeaturizerSuite.scala, HourOfDayFeaturizerSuite.scala, MonthOfYearFeaturizerSuite.scala
src/main/scala/com/adobe/platform/ml/feature/util/TemporalFeaturizerUtils.scala
src/test/scala/com/adobe/platform/ml/feature/unary/temporal/DayOfWeekFeaturizerSuite.scala
src/test/scala/com/adobe/platform/ml/feature/unary/temporal/HourOfDayFeaturizerSuite.scala
src/test/scala/com/adobe/platform/ml/feature/unary/temporal/MonthOfYearFeaturizerSuite.scala